### PR TITLE
Add option to specify version when generate new package

### DIFF
--- a/src/Octower/Command/DeployCommand.php
+++ b/src/Octower/Command/DeployCommand.php
@@ -33,6 +33,7 @@ EOT
             )
             ->addArgument('remote', InputArgument::REQUIRED)
             ->addArgument('package', InputArgument::OPTIONAL)
+            ->addOption('version', 'v', InputOption::VALUE_OPTIONAL)
             ->addOption('generate', 'g', InputOption::VALUE_NONE)
             ->addOption('override', 'o', InputOption::VALUE_OPTIONAL, 'Override remote information for connecting');
     }
@@ -45,6 +46,7 @@ EOT
         if (!$octower->getContext() instanceof Project) {
             throw new \RuntimeException('The current context is not a project context.');
         }
+
 
         /** @var Project $project */
         $project = $octower->getContext();
@@ -60,7 +62,16 @@ EOT
         if ($input->getOption('generate')) {
             $packager    = Packager::create($io, $octower);
             $packagePath = $packager->run(rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR), uniqid('octower-package'));
+
+            if ($input->hasOption('version')) {
+                $project->setVersion($input->getOption('version'));
+            }
+
         } else {
+            if ($input->hasOption('version')) {
+                throw new InvalidArgumentException('Unable to set a version if you choose to deploy an existing package.');
+            }
+
             $packagePath = realpath(trim($input->getArgument('package')));
         }
 

--- a/src/Octower/Command/PackageCommand.php
+++ b/src/Octower/Command/PackageCommand.php
@@ -11,9 +11,10 @@
 
 namespace Octower\Command;
 
-use Octower\Octower;
+use Octower\Metadata\Project;
 use Octower\Packager;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class PackageCommand extends Command
@@ -23,6 +24,7 @@ class PackageCommand extends Command
         $this
             ->setName('package:generate')
             ->setDescription('Create package to deploy')
+            ->addOption('version', 'v', InputOption::VALUE_OPTIONAL)
             ->setHelp(<<<EOT
 <info>php octower.phar package:generate</info>
 EOT
@@ -33,6 +35,13 @@ EOT
     {
         $octower = $this->getOctower();
         $io = $this->getIO();
+
+        if ($input->hasOption('version')) {
+            $context = $octower->getContext();
+            if ($context instanceof Project) {
+                $context->setVersion($input->getOption('version'));
+            }
+        }
 
         $packager = Packager::create($io, $octower);
         $packager->run();


### PR DESCRIPTION
This option will be available in package:generate & deploy commands.

This option will cut-off auto-calculation of the package version.
