### PR TITLE
Test remote existence at the beginning of deploy process

### DIFF
--- a/src/Octower/Command/DeployCommand.php
+++ b/src/Octower/Command/DeployCommand.php
@@ -50,6 +50,7 @@ EOT
 
         /** @var Project $project */
         $project = $octower->getContext();
+        $remote = $project->getRemote($input->getArgument('remote'));
 
         if (!$input->getOption('generate') && strlen($input->getArgument('package')) == 0) {
             throw new InvalidArgumentException('No package provided and no --generate flag used.');
@@ -76,7 +77,6 @@ EOT
         }
 
         // Contact the server
-        $remote = $project->getRemote($input->getArgument('remote'));
         $remote->override(json_decode($input->getOption('override'), true));
 
         $deployer = Deployer::create($this->getIO(), $this->getOctower());


### PR DESCRIPTION
fix #34 

Try to get remote before package test or generation to detect use of an invalid remote before package processing (generation might be a bit longer and useless if remote doesn't exist)