### PR TITLE
refs #52 - add autoload_static.php in_path

### DIFF
--- a/src/Octower/Compiler.php
+++ b/src/Octower/Compiler.php
@@ -99,6 +99,7 @@ class Compiler
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_psr4.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_classmap.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_real.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_static.php'));
         if (file_exists(__DIR__.'/../../vendor/composer/include_paths.php')) {
             $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/include_paths.php'));
         }


### PR DESCRIPTION
in Octower/Compiler, `vendor/composer/autoload_static.php` was not added in the phar, thus not found when required